### PR TITLE
chore: use LTS tagged node images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   qa:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:lts
     steps:
       - checkout
       - run:
@@ -22,7 +22,7 @@ jobs:
           command: yarn publish-coverage
   docker-build-push:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:lts
     steps:
       - checkout
       - setup_remote_docker
@@ -46,7 +46,7 @@ jobs:
             docker push staticdeploy/app-server:$DOCKER_TAG-cra-runtime
   npm-publish:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:lts
     steps:
       - checkout
       - run:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-alpine
+FROM node:lts-alpine
 
 # Install app-server into directory /app-server
 WORKDIR /app-server

--- a/docker/Dockerfile.cra-builder
+++ b/docker/Dockerfile.cra-builder
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:lts
 
 ONBUILD WORKDIR /app
 


### PR DESCRIPTION
This PR update all Dockerfiles to use LTS tagged node images (for both CI and runtime).